### PR TITLE
Fix exception "Value cannot be longer than 1024 characters"

### DIFF
--- a/src/main/kotlin/xyz/gnarbot/gnar/commands/executors/music/QueueCommand.kt
+++ b/src/main/kotlin/xyz/gnarbot/gnar/commands/executors/music/QueueCommand.kt
@@ -24,6 +24,7 @@ class QueueCommand : MusicExecutor() {
 
         var trackCount = 0
         var queueLength = 0L
+        var messageLength = 0
 
         val eb = EmbedBuilder()
 
@@ -42,12 +43,12 @@ class QueueCommand : MusicExecutor() {
             queueLength += track.duration
             trackCount++
             if (track.sourceManager.sourceName.contains("youtube")){
-                sj.add("**$trackCount** `[${getTimestamp(track.duration)}]` __[${track.info.title}](https://youtube.com/watch?v=${track.info.identifier})__")
+                messageLength += sj.add("**$trackCount** `[${getTimestamp(track.duration)}]` __[${track.info.title}](https://youtube.com/watch?v=${track.info.identifier})__").length()
             } else {
-                sj.add("**$trackCount** `[${getTimestamp(track.duration)}]` __[${track.info.title}]()__")
+                messageLength += sj.add("**$trackCount** `[${getTimestamp(track.duration)}]` __[${track.info.title}]()__").length()
             }
 
-            if (trackCount >= 10) {
+            if (messageLength >= 900) {
                 sj.add("... and **${queue.size - trackCount}** more tracks.")
                 break
             }


### PR DESCRIPTION
This is in command _queue
I added a variable to count the length of message.
Now message will not exceed 900 characters and will be sended without exception about that value cannot be longer than 1024 characters.